### PR TITLE
Add unzip to fix composer warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update; \
         openssl \
         nano \
         openssh-client \
+        unzip \
     ; \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes composer warning:
```
As there is no 'unzip' command installed zip files are being unpacked using the PHP zip extension.
This may cause invalid reports of corrupted archives. Besides, any UNIX permissions (e.g. executable) defined in the archives will be lost.
Installing 'unzip' may remediate them.
```

It is recommended to use the native unzip binary because the php-zip extensions is not 100% compatible with all zip features.

Ref https://getcomposer.org/doc/articles/troubleshooting.md#zip-archives-are-not-unpacked-correctly-