### PR TITLE
Skip audit on npm install

### DIFF
--- a/remote.sh
+++ b/remote.sh
@@ -243,12 +243,12 @@ if [ -n "$BRANCH" ] && ! [ -f "/var/www/$APPID-completed" ]; then
 
     # Fix npm ci for mail
     if [ "$APPID" = mail ]; then
-        npm install
+        npm install --no-audit
     fi
 
     # Compile apps
     if [ -f package.json ]; then
-        if ! npm ci || ! npm run dev --if-present; then
+        if ! npm ci --no-audit || ! npm run dev --if-present; then
             echo "Could not compile the $APPID app."
             exit 1
         fi


### PR DESCRIPTION
Reduce time to install each app. This will skip checking for vulnerabilities and printing a summary.