### PR TITLE
Allow to set the used Xdebug mode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -172,5 +172,7 @@ If one of the above variables are set via e.g. `-e CALENDAR_BRANCH=master` durin
 
 `NEXTCLOUDVUE_BRANCH` if the variable is set it will compile javascript files for the chosen nextcloud vue branch and automatically link all chosen apps that use nextcloud vue and additionally the server if COMPILE_SERVER is set.
 
+`XDEBUG_MODE` if the variable is set it will change the Xdebug mode to the set value. For example debug, trace or profile can be used. If the variable is not set, Xdebug mode will be `off` by default.
+
 ## How does it work?
 The docker image comes pre-bundled with all needed dependencies for a minimal instance of Nextcloud and allows to define a target branch via environmental variables that will automatically be cloned and compiled during the container startup. For a refresh, you need to recreate the container by first removing it and then running the same command again.

--- a/remote.sh
+++ b/remote.sh
@@ -372,6 +372,11 @@ if ! php -f occ maintenance:repair; then
     exit 1
 fi
 
+# Set Xdebug options
+if [ -n "$XDEBUG_MODE" ]; then
+    sed -i 's/^xdebug.mode\s*=\s*.*/xdebug.mode='"$XDEBUG_MODE"'/g' /usr/local/etc/php/conf.d/xdebug.ini
+fi
+
 # Show how to reach the server
 show_startup_info
 print_green "You can log in with the user 'admin' and its password 'nextcloud'"


### PR DESCRIPTION
This PR allows to set the used xdebug mode. Basically taken from here https://github.com/juliushaertl/nextcloud-docker-dev/blob/master/scripts/php-mod-config

When looking at the documentation of xdebug, you can also use XDEBUG_MODE directly as an environment variable. So, not sure if this is needed at all or if we should use a different name for this variable?! https://xdebug.org/docs/all_settings#mode