### PR TITLE
Implement handling of custom repository names

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -163,6 +163,8 @@ ZIPPER_BRANCH
 
 If one of the above variables are set via e.g. `-e CALENDAR_BRANCH=master` during the initial container creation, then will the container automatically get the chosen branch from github and compile and enable the chosen apps on the instance during the startup.
 
+Branches from custom forks can be installed as well. Use `-e CALENDAR_BRANCH=user:main` to install the `main` branch from the fork of `user`. If the fork has a different name (e.g. nextcloud-calendar), you can use the extended format `-e CALENDAR_BRANCH=user:main@nextcloud-calendar` to pull the branch `main` of the repo `user/nextcloud-calendar`. This format can be used with all app branch variables including `SERVER_BRANCH` and `NEXTCLOUDVUE_BRANCH`.
+
 ### Other variables
 `MANUAL_INSTALL` if the variable is set, it will skip all apps variables and only clone the given server branch and start Apache directly. You will then be able to provide your own credentials and install recommended apps.
 

--- a/remote.sh
+++ b/remote.sh
@@ -86,11 +86,16 @@ install_nextcloud_vue() {
         set -x
         local VUE_OWNER="${NEXTCLOUDVUE_BRANCH%%:*}"
         local VUE_BRANCH="${NEXTCLOUDVUE_BRANCH#*:}"
+        local VUE_REPO=nextcloud-vue
+        if echo "$VUE_BRANCH" | grep -q '@'; then
+            VUE_REPO="${VUE_BRANCH#*@}"
+            VUE_BRANCH="${VUE_BRANCH%%@*}"
+        fi
         set +x
         mkdir /var/www/nextcloud-vue
         cd /var/www/nextcloud-vue || exit
-        if ! git clone https://github.com/"$VUE_OWNER"/nextcloud-vue.git --branch "$VUE_BRANCH" --single-branch --depth 1 .; then
-            echo "Could not clone the requested nextcloud vue branch '$VUE_BRANCH' of '$VUE_OWNER'. Does it exist?"
+        if ! git clone https://github.com/"$VUE_OWNER"/"$VUE_REPO".git --branch "$VUE_BRANCH" --single-branch --depth 1 .; then
+            echo "Could not clone the requested nextcloud vue branch '$VUE_BRANCH' of '$VUE_OWNER/$VUE_REPO'. Does it exist?"
             exit 1
         fi
 
@@ -143,10 +148,15 @@ if ! [ -f /var/www/server-completed ]; then
     set -x
     FORK_OWNER="${SERVER_BRANCH%%:*}"
     FORK_BRANCH="${SERVER_BRANCH#*:}"
+    FORK_REPO=server
+    if echo "$FORK_BRANCH" | grep -q '@'; then
+        FORK_REPO="${FORK_BRANCH#*@}"
+        FORK_BRANCH="${FORK_BRANCH%%@*}"
+    fi
     set +x
     cd /var/www/nextcloud || exit
-    if ! git clone https://github.com/"$FORK_OWNER"/server.git --branch "$FORK_BRANCH" --single-branch --depth 1 .; then
-        echo "Could not clone the requested server branch '$FORK_BRANCH' of '$FORK_OWNER'. Does it exist?"
+    if ! git clone https://github.com/"$FORK_OWNER"/"$FORK_REPO".git --branch "$FORK_BRANCH" --single-branch --depth 1 .; then
+        echo "Could not clone the requested server branch '$FORK_BRANCH' of '$FORK_OWNER/$FORK_REPO'. Does it exist?"
         exit 1
     fi
 
@@ -267,9 +277,14 @@ if [ -n "$BRANCH" ] && ! [ -f "/var/www/$APPID-completed" ]; then
     set -x
     local APP_OWNER="${BRANCH%%:*}"
     local APP_BRANCH="${BRANCH#*:}"
+    local APP_REPO="$APPID"
+    if echo "$APP_BRANCH" | grep -q '@'; then
+        APP_REPO="${APP_BRANCH#*@}"
+        APP_BRANCH="${APP_BRANCH%%@*}"
+    fi
     set +x
-    if ! git clone https://github.com/"$APP_OWNER"/"$APPID".git --branch "$APP_BRANCH" --single-branch --depth 1; then
-        echo "Could not clone the requested branch '$APP_BRANCH' of the $APPID app of '$APP_OWNER'. Does it exist?"
+    if ! git clone https://github.com/"$APP_OWNER"/"$APP_REPO".git --branch "$APP_BRANCH" --single-branch --depth 1 "$APPID"; then
+        echo "Could not clone the requested branch '$APP_BRANCH' of the $APPID app of '$APP_OWNER/$APP_REPO'. Does it exist?"
         exit 1
     fi
 


### PR DESCRIPTION
Some contributors fork our repositories with custom names, e.g. server vs [nextcloud-server](https://github.com/10imaging/nextcloud-server). I implemented handling custom fork names by extending the `*_BRANCH` format while maintaining backwards compatibility. I also updated the readme to inform users about this change.


[Custom fork names are not used for nextcloud-vue](https://github.com/nextcloud/nextcloud-vue/network/members) but I also applied this new format to it for consistency.

| Format | Status | Example |
| --- | --- | --- |
| Basic format | still compatible | `branch` |
| Custom owner | still compatible | `owner:branch` |
| Extended format | new | `owner:branch@repo` |

I tested all three variations locally.