### PR TITLE
Set various server configs through env variables

### DIFF
--- a/remote.sh
+++ b/remote.sh
@@ -201,6 +201,18 @@ if ! [ -f /var/www/server-completed ]; then
             exit 1
         fi
     fi
+
+    # Set reverse proxy configs
+    [ -n "$OVERWRITE_CLI_URL" ] && php -f occ config:system:set overwrite.cli.url --value="$OVERWRITE_CLI_URL"
+    [ -n "$OVERWRITE_PROTOCOL" ] && php -f occ config:system:set overwriteprotocol --value="$OVERWRITE_PROTOCOL"
+    [ -n "$OVERWRITE_HOST" ] && php -f occ config:system:set overwritehost --value="$OVERWRITE_HOST"
+
+    # Configure pretty urls
+    if [ -n "$ENABLE_PRETTY_URLS" ]; then
+        php -f occ config:system:set htaccess.RewriteBase --value=/
+        php -f occ maintenance:update:htaccess
+    fi
+
     touch /var/www/server-completed
 fi
 


### PR DESCRIPTION
These are some options I have been using on my fork for a long time. They enable testing some advanced features and make it easier to run multiple nc-easy-test instances in parallel.

If you think this PR would be a great addition, I'll also amend the readme.

Otherwise, feel free to close the PR. Those settings might be out of scope for a simple testing image.