### PR TITLE
Fix occ script

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,5 +16,6 @@ jobs:
       uses: ludeeus/action-shellcheck@master
       with:
         check_together: 'yes'
+        additional_files: 'occ'
       env:
         SHELLCHECK_OPTS: --shell bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,13 @@ RUN a2dissite 000-default && \
 # Copy start script
 COPY cron.sh /cron.sh
 COPY start.sh /usr/bin/
+
+# Replace occ script with fixed version
+COPY occ /usr/local/bin/occ
+
+# Make scripts executable
 RUN chmod +x /usr/bin/start.sh; \
+    chmod +x /usr/local/bin/occ; \
     chmod +x /cron.sh
 
 # Correctly set rights and add directories

--- a/occ
+++ b/occ
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec php -f /var/www/nextcloud/occ "$@"


### PR DESCRIPTION
The occ script from Julius' base image assumes that a shell is running as root. However, in nc-easy-test everything is run as www-data by default which breaks the default occ script.

I added a fixed version that also uses the correct path of the occ php script.

This also makes handling custom configs and debugging an instance easier as it can be used from a shell directly. e.g.

```sh
$ docker exec -ti nc-easy-test bash
www-data@c53fadc32893:~/html$ occ status
  - installed: true
  - version: 26.0.0.3
  - versionstring: 26.0.0 beta 1
  - edition:
  - maintenance: false
  - needsDbUpgrade: false
  - productname: Nextcloud
  - extendedSupport: false
www-data@c53fadc32893:~/html$
```
