### PR TITLE
Added custom local apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -191,8 +191,8 @@ Branches from custom forks can be installed as well. Use `-e CALENDAR_BRANCH=use
 - `APACHE_PORT` if the variable is set, it will instead of the default port 443 inside the container, use the chosen Port for APACHE.
 - `NEXTCLOUDVUE_BRANCH` if the variable is set it will compile javascript files for the chosen nextcloud vue branch and automatically link all chosen apps that use nextcloud vue and additionally the server if COMPILE_SERVER is set.
 - `XDEBUG_MODE` if the variable is set it will change the Xdebug mode to the set value. For example `debug`, `trace` or `profile` can be used. If the variable is not set, Xdebug mode will be `off` by default.
-
-`NEXTCLOUD_LOGLEVEL` this can modify the loglevel of Nextcloud and must be an integer. By default it is set to 3. Valid values are: 0 = Debug, 1 = Info, 2 = Warning, 3 = Error, and 4 = Fatal.
+- `CUSTOM_LOCALAPP` if the variable is set it will allow another directory to be used for apps; when used with a bind volume and the appropriate permissions, custom local apps could be used, or tested. If set to true, the default directory, and URL is `localapps`; otherwise a custom directory/URL can be created by adding an arbitary string as the variable (`e.g. -e CUSTOM_LOCALAPP=myapps`).
+- `NEXTCLOUD_LOGLEVEL` this can modify the loglevel of Nextcloud and must be an integer. By default it is set to 3. Valid values are: 0 = Debug, 1 = Info, 2 = Warning, 3 = Error, and 4 = Fatal.
 
 ## How does it work?
 The docker image comes pre-bundled with all needed dependencies for a minimal instance of Nextcloud and allows to define a target branch via environmental variables that will automatically be cloned and compiled during the container startup. For a refresh, you need to recreate the container by first removing it and then running the same command again.

--- a/remote.sh
+++ b/remote.sh
@@ -142,6 +142,30 @@ link_nextcloud_vue() {
     fi
 }
 
+# Function to handle custom local apps
+# (Indentation used in this function is intentional)
+handle_custom_local_apps() {
+    sed -i "/);/i\
+  'apps_paths' => [
+    [
+    'path' => OC::$SERVERROOT . \"/apps\",
+    'url' => \"/apps\",
+    'writable' => false,
+    ],
+    [ 
+    'path' => OC::$SERVERROOT . \"/localapps\",
+    'url' => \"/localapps\",
+    'writable' => true,
+    ],
+  ],
+    " /var/www/nextcloud/config/config.php
+    if [[ "$CUSTOM_LOCALAPP" != "true" && "$CUSTOM_LOCALAPP" != "1" ]]; then
+        sed -i "s|/localapp|/$CUSTOM_LOCALAPP|g" filename.txt
+    fi
+    # Potentional cleanup
+    sed -i "s|//|/|g" filename.txt
+}
+
 # Handle empty server branch variable
 if [ -z "$SERVER_BRANCH" ]; then
     export SERVER_BRANCH="nextcloud:master"
@@ -428,6 +452,11 @@ install_enable_app "$TWOFACTORWEBAUTHN_BRANCH" twofactor_webauthn
 install_enable_app "$TWOFACTORTOTP_BRANCH" twofactor_totp
 install_enable_app "$VIEWER_BRANCH" viewer
 install_enable_app "$ZIPPER_BRANCH" files_zip
+
+# Handle custom local apps
+if [ -n "$CUSTOM_LOCALAPP" ]; then
+    handle_custom_local_apps
+fi
 
 # Clear cache
 cd /var/www/nextcloud || exit


### PR DESCRIPTION
Adds the ability to bind a second apps directory, so the user can add apps locally
Fixes issue #43 

```
docker run -it \
-e SERVER_BRANCH=master \
-e CUSTOM_LOCALAPP=myapps \
--name nextcloud-easy-test \
-p 127.0.0.1:8443:443 \
--volume="nextcloud_easy_test_npm_cache_volume:/var/www/.npm" \
--volume="/path/to/local/directory:/var/www/nextcloud/myapps" \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

Something to that effect, at least.


HTH